### PR TITLE
Fixes Nil Error 

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -61,7 +61,7 @@ textadept.editing.autocompleters.javascript = function()
   local list = {}
   -- Retrieve the symbol behind the caret.
   local line, pos = buffer:get_cur_line()
-  
+
   local symbol = ''
   local rawsymbol, op, part = line:sub(1, pos):match('([%w_%$#%.%-=\'"%[%]/%(%)]-)(%.?)([%w_%$]*)$')
   -- identify literals like "'foo'." and "[1, 2, 3].".
@@ -76,12 +76,12 @@ textadept.editing.autocompleters.javascript = function()
   elseif part == '' then
     return nil -- nothing to complete
   end
-  
+
   -- Attempt to identify the symbol type.
   if rawsymbol and symbol == '' then
     symbol = rawsymbol:match('([%w_%$%.]*)$')
     if symbol == '' and part == '' then return nil end -- nothing to complete
-    
+
     if symbol ~= '' then
       local buffer = buffer
       local assignment = symbol:gsub('(%p)', '%%%1')..'%s*=%s*(.*)$'
@@ -112,15 +112,17 @@ textadept.editing.autocompleters.javascript = function()
         elseif not list[name] then
           hasFound = true
           local fields = line:match(';"\t(.*)$')
-          local k, class = fields:sub(1, 1), fields:match('class:(%S+)') or ''
-          
-          if class == symbol or (op == '' and class == 'window')
-                             or (op == '.' and class == 'Object' and symbol ~= 'jQuery') then
-            list[#list + 1] = string.format('%s%s%d', name, sep, xpms[k])
-            list[name] = true
-          elseif has_value(M.child_classes[class], symbol) then
-            list[#list + 1] = string.format('%s%s%d', name, sep, xpms[k])
-            list[name] = true
+          if fields ~= nil then
+            local k, class = fields:sub(1, 1), fields:match('class:(%S+)') or ''
+
+            if class == symbol or (op == '' and class == 'window')
+                               or (op == '.' and class == 'Object' and symbol ~= 'jQuery') then
+              list[#list + 1] = string.format('%s%s%d', name, sep, xpms[k])
+              list[name] = true
+            elseif has_value(M.child_classes[class], symbol) then
+              list[#list + 1] = string.format('%s%s%d', name, sep, xpms[k])
+              list[name] = true
+            end
           end
         end
       end


### PR DESCRIPTION
Found this randomly and it's working really well. Thanks for this! I was getting a fairly trivial nil reference error due to the format of my generated ctags file. I fixed it and figured you'd want the change as well. I realize this is a bit of a drive by pull request, please do let me know if you want to change anything in here.

Commit message:
Per project generated ctags were causing an error due to the preamble in the ctags file. That `tags` file looks something like this

```
!_TAG_FILE_FORMAT       2       /extended format; --format=1 will not append ;" to lines/
!_TAG_FILE_SORTED       1       /0=unsorted, 1=sorted, 2=foldcase/
!_TAG_PROGRAM_AUTHOR    Darren Hiebert  /dhiebert@users.sourceforge.net/
!_TAG_PROGRAM_NAME      Exuberant Ctags //
!_TAG_PROGRAM_URL       http://ctags.sourceforge.net    /official site/
!_TAG_PROGRAM_VERSION   5.9~svn20110310 //
Something   source/something.js /^}$/;" c
```

The lines prefixed with `!` were causing fields to be nil.

Added a nil check which effectively ignores those lines in the preamble